### PR TITLE
ansible: set trust-model to always for vault handling scripts

### DIFF
--- a/ansible/gpg/gpg2.sh
+++ b/ansible/gpg/gpg2.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-exec gpg2 --keyring "${BASH_SOURCE%/*}/vault-keyring.gpg" --secret-keyring /dev/null --no-default-keyring $@
+exec gpg2 --keyring "${BASH_SOURCE%/*}/vault-keyring.gpg" --secret-keyring /dev/null --no-default-keyring --trust-model always $@


### PR DESCRIPTION
removes annoying warnings and there is nothing to be trusted here...