### PR TITLE
Travis: Install ImageMagick's Perl bindings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
       - graphviz
       - ikiwiki
       - imagemagick
+      - libimage-magick-perl
       - libtext-markdown-discount-perl
       - libtext-typography-perl
 


### PR DESCRIPTION
This should fix the “Image::Magick is not installed” error.