### PR TITLE
fix ssh config after merging gnocci/setup

### DIFF
--- a/ansible/hosts.ini
+++ b/ansible/hosts.ini
@@ -13,7 +13,7 @@ galley
 hacksch
 r3home
 tickets
-gnocci[0:1]
+gnocchi[0:1]
 
 ## TODO: remove the variable once https://github.com/ansible/ansible/issues/39119 is fixed
 metrics localconfig_ssh_config_user=root
@@ -26,11 +26,11 @@ host_domain=mgmt.realraum.at
 
 [baremetalservers]
 alfred
-gnocci[0:1]
+gnocchi[0:1]
 
 [kvmhosts]
 alfred
-gnocci[0:1]
+gnocchi[0:1]
 
 
 [virtualservers]
@@ -75,4 +75,4 @@ localconfig_ssh_config_user=root
 #torwaechter
 
 [apu]
-gnocci[0:1]
+gnocchi[0:1]

--- a/ansible/hosts.ini
+++ b/ansible/hosts.ini
@@ -75,4 +75,4 @@ localconfig_ssh_config_user=root
 #torwaechter
 
 [apu]
-gnocchi[0:1]
+gnocci[0:1]

--- a/ansible/roles/localconfig/templates/ssh/10r3.conf.j2
+++ b/ansible/roles/localconfig/templates/ssh/10r3.conf.j2
@@ -24,12 +24,6 @@ Host {{ hostvars[host].ansible_host }} r3-{{ host }} r3g-{{ host }} r3e-{{ host 
 Host gw.realraum.at r3-gw
     Hostname gw.realraum.at
 
-Host gnocchi1.realraum.at r3-gnocchi1
-    Hostname gnocchi1.realraum.at
-
-Host gnocchi2.realraum.at r3-gnocchi2
-    Hostname gnocchi2.realraum.at
-
 Host ap0.mgmt.realraum.at r3g-ap0
     Hostname ap0.mgmt.realraum.at
     User root

--- a/doc/gnocchi.org
+++ b/doc/gnocchi.org
@@ -22,11 +22,11 @@
 *** TODO Move gnocchis to the rack in W1
     Assigned: nicoo
 *** TODO Setup [3/9]
-**** DONE Adapt vm/setup to be able to bring up Gnocci VMs
+**** DONE Adapt vm/setup to be able to bring up Gnocchi VMs
      CLOSED: [2018-06-17 Sun 12:32]
 
      vm/setup had implicit assumptions about network which might not have
-     held when installing core network VMs on gnocci
+     held when installing core network VMs on gnocchi
 
      It now only needs connectivity on the VM's primary interface,
      to the configured debian mirror.


### PR DESCRIPTION
What was the outcome of the discussion regarding the misspelled name again? For now everything concerning these hosts is named gnocci. I actually had to fix some DNS entries to achieve this. 

The actual name of the dish is gnocchi.... so shall we change it to this?