### PR TITLE
nicer handling for ssh keys

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -14,6 +14,8 @@ var_compression_level = 9
 
 timeout=30
 
+filter_plugins = ./filter_plugins
+
 [ssh_connection]
 pipelining = True
 ssh_args = -C -o ControlMaster=auto -o ControlPersist=60s

--- a/ansible/filter_plugins/users.py
+++ b/ansible/filter_plugins/users.py
@@ -1,0 +1,30 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible import errors
+
+
+def user_ssh_keys(data, db):
+    try:
+        ssh_keys = []
+        for user in data:
+            try:
+                for key in db[user]['ssh']:
+                    ssh_keys.append(key)
+            except KeyError:
+                pass
+
+        return ssh_keys
+    except Exception as e:
+        raise errors.AnsibleFilterError("user_ssh_keys(): %s" % str(e))
+
+
+class FilterModule(object):
+
+    ''' extract values form users db '''
+    filter_map = {
+        'user_ssh_keys': user_ssh_keys,
+    }
+
+    def filters(self):
+        return self.filter_map

--- a/ansible/group_vars/accesspoints/main.yml
+++ b/ansible/group_vars/accesspoints/main.yml
@@ -1,4 +1,8 @@
 ---
+ssh_root_users:
+  - equinox
+  - nicoo
+
 accesspoint_wifi_channels:
   2.4g:
     ap0: 3
@@ -142,7 +146,7 @@ openwrt_mixin:
 
   /etc/dropbear/authorized_keys:
     content: |-
-      {% for key in noc_ssh_keys %}
+      {% for key in ssh_keys_root %}
       {{ key }}
       {% endfor %}
 

--- a/ansible/group_vars/accesspoints/main.yml
+++ b/ansible/group_vars/accesspoints/main.yml
@@ -145,10 +145,7 @@ openwrt_mixin:
       net.ipv6.conf.all.forwarding=0
 
   /etc/dropbear/authorized_keys:
-    content: |-
-      {% for key in ssh_users_root | user_ssh_keys(users) %}
-      {{ key }}
-      {% endfor %}
+    content: "{{ ssh_users_root | user_ssh_keys(users) | join('\n') }}\n"
 
   /etc/htoprc:
     file: "{{ global_files_dir }}/common/htoprc"

--- a/ansible/group_vars/accesspoints/main.yml
+++ b/ansible/group_vars/accesspoints/main.yml
@@ -1,5 +1,5 @@
 ---
-ssh_root_users:
+ssh_users_root:
   - equinox
   - nicoo
 
@@ -146,7 +146,7 @@ openwrt_mixin:
 
   /etc/dropbear/authorized_keys:
     content: |-
-      {% for key in ssh_keys_root %}
+      {% for key in ssh_users_root | user_ssh_keys(users) %}
       {{ key }}
       {% endfor %}
 

--- a/ansible/group_vars/all/main.yml
+++ b/ansible/group_vars/all/main.yml
@@ -10,4 +10,12 @@ global_files_dir: "{{ inventory_dir }}/files"
 ## Root password; by default, undefined
 root_password: "{{ vault_root_password }}"
 ## SSH keys for root, default to NOC's
-ssh_keys: "{{ noc_ssh_keys }}"
+
+ssh_users_root: "{{ user_groups.noc }}"
+## TODO: make this a filter_plugin...
+ssh_keys_root: "{{ ssh_users_root | map('extract', users) | map(attribute='ssh') | flatten | list }}"
+
+## TODO: not used at the moment?
+noc_groups:
+  - adm
+  - sudo

--- a/ansible/group_vars/all/main.yml
+++ b/ansible/group_vars/all/main.yml
@@ -12,10 +12,3 @@ root_password: "{{ vault_root_password }}"
 ## SSH keys for root, default to NOC's
 
 ssh_users_root: "{{ user_groups.noc }}"
-## TODO: make this a filter_plugin...
-ssh_keys_root: "{{ ssh_users_root | map('extract', users) | map(attribute='ssh') | flatten | list }}"
-
-## TODO: not used at the moment?
-noc_groups:
-  - adm
-  - sudo

--- a/ansible/group_vars/all/users.yml
+++ b/ansible/group_vars/all/users.yml
@@ -30,9 +30,3 @@ users:
     gpg: 0xE3468B9CE81EB4F91486
     ssh:
       - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDsT6W8Yz9iQ9FXuyrBmLC3o1j26ugzKfJDjvYAOehtjbYj+JjNrLoob1Evg5wWbDI9w+GiaBRKpfMw/66rMty8UXnYvpr28AsMdsxmvCp7k6eW55WcWNC26Nw3cWJo8MBxDaWDfjPdVzhKU7iFTCEVz/mUqUrbyg+Y6R1psqY84zXwelyPNPUVNBSaWMORmWR397v8UaEx2jsO4Nxaw1w4RnJSyq5feXResLigh6yelCNDWu3ISQrmZtjKRCPWlVzIDAT5m0UZzHjfGtixei8QNo3Y1sNUyFmrR0jcy6Uvkcl2ryGsUApCqaIGHz9zNvVJo7lGFH7yDVnaFx2XHnbDrZqhcvtvKK9kJkXwpTwASnSg7CB4VUFxdfzOlwnGUqMrePYqN5CaFKLNNQ5vIharK+iikvgkibrCSH69Tdb26IvBpXojuoIHDpBNcAAy5d66P+EoUXv7xWVmWiDLyJd66GvNzAzwel16KrjlgYZoKaj5rAB04qafSi6gRKJMuxQTBGGBc45JojDDZUEQht0/0N9GEWZDAO2z3eyB0lsODNvJBh9jAvwEOMcNnm59GYnYrk4bKLS1GEvq6a0aQvAxJDj0OxENNsx3SloYnP+ufHUZvWI9Ccu+9PMcoNqsFomiFg5nraL7NVaaOegVVYVGr4xZm9Yl/fnfnkH/lccsPw== xro@realraum.at
-
-noc_groups:
-  - adm
-  - sudo
-
-noc_ssh_keys: "{{ user_groups.noc | map('extract', users) | map(attribute='ssh') | flatten | list }}"

--- a/ansible/host_vars/torwaechter/main.yml
+++ b/ansible/host_vars/torwaechter/main.yml
@@ -1,4 +1,6 @@
 ---
+ssh_keys_tuergit: "{{ ssh_keys_root }}"
+
 openwrt_arch: x86
 openwrt_target: geode
 openwrt_output_image_suffixes:
@@ -59,13 +61,13 @@ openwrt_mixin:
 
   /etc/ssh/authorized_keys.d/root:
     content: |-
-      {% for key in noc_ssh_keys %}
+      {% for key in ssh_keys_root %}
       {{ key }}
       {% endfor %}
 
   /etc/ssh/authorized_keys.d/tuergit:
     content: |-
-      {% for key in noc_ssh_keys %}
+      {% for key in ssh_keys_tuergit %}
       {{ key }}
       {% endfor %}
 

--- a/ansible/host_vars/torwaechter/main.yml
+++ b/ansible/host_vars/torwaechter/main.yml
@@ -60,16 +60,10 @@ openwrt_mixin:
         AuthorizedKeysCommandUser tuergit
 
   /etc/ssh/authorized_keys.d/root:
-    content: |-
-      {% for key in ssh_users_root | user_ssh_keys(users) %}
-      {{ key }}
-      {% endfor %}
+    content: "{{ ssh_users_root | user_ssh_keys(users) | join('\n') }}\n"
 
   /etc/ssh/authorized_keys.d/tuergit:
-    content: |-
-      {% for key in ssh_users_tuergit | user_ssh_keys(users) %}
-      {{ key }}
-      {% endfor %}
+    content: "{{ ssh_users_tuergit | user_ssh_keys(users) | join('\n') }}\n"
 
 openwrt_uci:
   system:

--- a/ansible/host_vars/torwaechter/main.yml
+++ b/ansible/host_vars/torwaechter/main.yml
@@ -1,5 +1,5 @@
 ---
-ssh_keys_tuergit: "{{ ssh_keys_root }}"
+ssh_users_tuergit: "{{ user_groups.noc }}"
 
 openwrt_arch: x86
 openwrt_target: geode
@@ -61,13 +61,13 @@ openwrt_mixin:
 
   /etc/ssh/authorized_keys.d/root:
     content: |-
-      {% for key in ssh_keys_root %}
+      {% for key in ssh_users_root | user_ssh_keys(users) %}
       {{ key }}
       {% endfor %}
 
   /etc/ssh/authorized_keys.d/tuergit:
     content: |-
-      {% for key in ssh_keys_tuergit %}
+      {% for key in ssh_users_tuergit | user_ssh_keys(users) %}
       {{ key }}
       {% endfor %}
 

--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -47,7 +47,7 @@
 - name: Set authorized keys for root user
   authorized_key:
     user: root
-    key: "{{ ssh_keys_root | join('\n') }}"
+    key: "{{ ssh_users_root | user_ssh_keys(users) | join('\n') }}"
     exclusive: yes
 
 - name: disable apt suggests and recommends

--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -47,7 +47,7 @@
 - name: Set authorized keys for root user
   authorized_key:
     user: root
-    key: "{{ ssh_keys | join('\n') }}"
+    key: "{{ ssh_keys_root | join('\n') }}"
     exclusive: yes
 
 - name: disable apt suggests and recommends

--- a/ansible/roles/preseed/tasks/main.yml
+++ b/ansible/roles/preseed/tasks/main.yml
@@ -14,7 +14,7 @@
     user: root
     manage_dir: no
     path: "{{ preseed_tmpdir }}/authorized_keys"
-    key: "{{ ssh_keys | join('\n') }}"
+    key: "{{ ssh_keys_root | join('\n') }}"
 
 - name: Inject files into initramfs
   shell: cpio -H newc -o | gzip -9 >> 'initrd.preseed.gz'

--- a/ansible/roles/preseed/tasks/main.yml
+++ b/ansible/roles/preseed/tasks/main.yml
@@ -14,7 +14,7 @@
     user: root
     manage_dir: no
     path: "{{ preseed_tmpdir }}/authorized_keys"
-    key: "{{ ssh_keys_root | join('\n') }}"
+    key: "{{ ssh_users_root | user_ssh_keys(users) | join('\n') }}"
 
 - name: Inject files into initramfs
   shell: cpio -H newc -o | gzip -9 >> 'initrd.preseed.gz'

--- a/ansible/roles/vm/install/tasks/main.yml
+++ b/ansible/roles/vm/install/tasks/main.yml
@@ -39,7 +39,7 @@
     - import_role:
         name: preseed
       vars:
-        ssh_keys: "{{ hostvars[hostname].ssh_keys }}"
+        ssh_keys_root: "{{ hostvars[hostname].ssh_keys_root }}"
         install_interface: enp1s1
         preseed_tmpdir: "{{ tmpdir.stdout }}"
 

--- a/ansible/roles/vm/install/tasks/main.yml
+++ b/ansible/roles/vm/install/tasks/main.yml
@@ -39,7 +39,7 @@
     - import_role:
         name: preseed
       vars:
-        ssh_keys_root: "{{ hostvars[hostname].ssh_keys_root }}"
+        ssh_users_root: "{{ hostvars[hostname].ssh_users_root }}"
         install_interface: enp1s1
         preseed_tmpdir: "{{ tmpdir.stdout }}"
 


### PR DESCRIPTION
The list of ssh keys is now generated from a list of usernames using the users database in `group_vars/all/users.yml`. 