### PR TITLE
add ansible-lint for roles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,16 @@ addons:
       - libimage-magick-perl
       - libtext-markdown-discount-perl
       - libtext-typography-perl
+      - python
+      - python-pip
 
-script: make -C doc
+install:
+  - pip install ansible
+  - pip install ansible-lint
+
+script:
+  - cd ansible; ansible-lint _lint_roles.yml
+  - make -C doc
 
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 sudo: no
+language: python
 addons:
   apt:
     packages:
@@ -9,8 +10,6 @@ addons:
       - libimage-magick-perl
       - libtext-markdown-discount-perl
       - libtext-typography-perl
-      - python
-      - python-pip
 
 install:
   - pip install ansible

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,9 @@ install:
   - ansible-lint --version
 
 script:
-  - cd ansible; ansible-lint _lint_roles.yml
+  - pushd ./ansible
+  - ansible-lint _lint_roles.yml
+  - popd
   - make -C doc
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,7 @@ install:
   - ansible-lint --version
 
 script:
-  - pushd ./ansible
-  - ansible-lint _lint_roles.yml
-  - popd
+  - ansible/lint.sh
   - make -C doc
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,7 @@ install:
   - ansible-lint --version
 
 script:
-  - pushd ./ansible
-  - ansible-lint _lint_roles.yml
-  - popd
+  - pushd ./ansible; ansible-lint _lint_roles.yml; popd
   - make -C doc
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ addons:
 install:
   - pip install ansible
   - pip install ansible-lint
+  - ansible --version
+  - ansible-lint --version
 
 script:
   - cd ansible; ansible-lint _lint_roles.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,9 @@ install:
   - ansible-lint --version
 
 script:
-  - pushd ./ansible; ansible-lint _lint_roles.yml; popd
+  - pushd ./ansible
+  - ansible-lint _lint_roles.yml
+  - popd
   - make -C doc
 
 deploy:

--- a/ansible/.ansible-lint
+++ b/ansible/.ansible-lint
@@ -1,0 +1,15 @@
+skip_list:
+  # These default rules (https://docs.ansible.com/ansible-lint/rules/default_rules.html) are deactivated:
+  #
+  # This list must contain only strings, so put the rule numbers in quotes
+  #
+  # Lines can be big and beautiful and don't need no linter!
+  - "204"
+  # Currently buggy in 4.0.0: https://github.com/ansible/ansible-lint/issues/443
+  - "404"
+  # Not a concern for us (internet is either stable or down, retries won't change that):
+  - "405"
+  # Our roles are generally not intended to go on Ansible Galaxy
+  - "701"
+  - "703"
+  - "704"

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -53,10 +53,11 @@ a specific task you can disable it by adding the following to the task:
   - skip_ansible_lint
 ```
 
-For now only roles are checked and every role must be manually added to the
-generic playbook [_lint_roles.yml](/ansible/_lint_roles.yml) in order to be checked.
+For now only roles and now playbooks are checked. Every role must be manually added
+to the generic playbook [_lint_roles.yml](/ansible/_lint_roles.yml) in order to be
+checked.
 If an entire role should be skipped please add it to the playbook commented out
-and supply a reason why this roles must be skipped.
+and supply a reason why this role must be skipped.
 
 
 Local ssh config

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -53,9 +53,9 @@ a specific task you can disable it by adding the following to the task:
   - skip_ansible_lint
 ```
 
-For now only roles and now playbooks are checked. Every role must be manually added
+For now only roles and no playbooks are checked. Every role must be manually added
 to the generic playbook [_lint_roles.yml](/ansible/_lint_roles.yml) in order to be
-checked.
+included.
 If an entire role should be skipped please add it to the playbook commented out
 and supply a reason why this role must be skipped.
 

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -40,6 +40,24 @@ ansible-playbook foo.yml
 ./apply-role.sh servers base -C -D
 ```
 
+ansible-lint
+------------
+
+We use ansible-lint to check all roles when changes are pushed to Github.
+Some rules have been globally disabled. See [.ansible-lint](/ansible/.ansible-lint)
+for a list of all disabled rules. If ansible-lint produces a false positive for
+a specific task you can disable it by adding the following to the task:
+
+```
+  tags:
+  - skip_ansible_lint
+```
+
+For now only roles are checked and every role must be manually added to the
+generic playbook [_lint_roles.yml](/ansible/_lint_roles.yml) in order to be checked.
+If an entire role should be skipped please add it to the playbook commented out
+and supply a reason why this roles must be skipped.
+
 
 Local ssh config
 ----------------

--- a/ansible/_lint_roles.yml
+++ b/ansible/_lint_roles.yml
@@ -8,14 +8,14 @@
 - hosts: invalid_host_name_by_design
   roles:
     - base
-#    - debian-installer
-#    - localconfig
-#    - openwrt/image
-#    - preseed
-#    - reboot-and-wait
-#    - usb-install
-#    - vm/grub
-#    - vm/guest
-#    - vm/host
-#    - vm/install
-#    - vm/network
+    - debian-installer
+    - localconfig
+    - openwrt/image
+    - preseed
+    - reboot-and-wait
+    - usb-install
+    - vm/grub
+    - vm/guest
+    - vm/host
+    - vm/install
+    - vm/network

--- a/ansible/_lint_roles.yml
+++ b/ansible/_lint_roles.yml
@@ -2,8 +2,8 @@
 ##
 ## This playbook is only used by ansible-lint to test all roles
 ##
-## TODO: uncomment roles once the syntax check runs through or document a reason
-##       why they are not included in this list
+##  If a role shouldn't be checked, add it commented-out and document a
+##  reason why it is not included in this list
 ##
 - hosts: invalid_host_name_by_design
   roles:

--- a/ansible/_lint_roles.yml
+++ b/ansible/_lint_roles.yml
@@ -1,0 +1,21 @@
+---
+##
+## This playbook is only used by ansible-lint to test all roles
+##
+## TODO: uncomment roles once the syntax check runs through or document a reason
+##       why they are not included in this list
+##
+- hosts: invalid_host_name_by_design
+  roles:
+    - base
+#    - debian-installer
+#    - localconfig
+#    - openwrt/image
+#    - preseed
+#    - reboot-and-wait
+#    - usb-install
+#    - vm/grub
+#    - vm/guest
+#    - vm/host
+#    - vm/install
+#    - vm/network

--- a/ansible/lint.sh
+++ b/ansible/lint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd "${BASH_SOURCE%/*}/"
+exec ansible-lint _lint_roles.yml

--- a/ansible/roles/base/tasks/01ssh.yml
+++ b/ansible/roles/base/tasks/01ssh.yml
@@ -1,5 +1,6 @@
 ---
-- set_fact:
+- name: generate list of users allowed to login via ssh
+  set_fact:
     sshd_allowusers: >-
       {{ [ 'root' ] | union(user_groups.noc)
                     | union(sshd_allowusers_group | default([]))

--- a/ansible/roles/openwrt/image/tasks/fetch.yml
+++ b/ansible/roles/openwrt/image/tasks/fetch.yml
@@ -48,5 +48,7 @@
         - "{{ openwrt_download_dir }}/{{ openwrt_tarball_basename }}.sha256"
         - "{{ openwrt_download_dir }}/{{ openwrt_tarball_basename }}.sha256.asc"
         - "{{ openwrt_download_dir }}/{{ openwrt_tarball_name }}"
-    - fail:
+
+    - name: the download has failed...
+      fail:
         msg: Something borked

--- a/ansible/roles/openwrt/image/tasks/main.yml
+++ b/ansible/roles/openwrt/image/tasks/main.yml
@@ -11,7 +11,8 @@
         path: "{{ openwrt_output_dir }}"
         state: directory
 
-    - set_fact:
+    - name: generate list of packages to add or remove
+      set_fact:
         openwrt_packages: >-
           {{ openwrt_packages_remove | map('regex_replace', '^', '-') | join(' ') }}
           {{ openwrt_packages_add   | join(' ') }}

--- a/ansible/roles/openwrt/image/tasks/prepare.yml
+++ b/ansible/roles/openwrt/image/tasks/prepare.yml
@@ -4,7 +4,8 @@
     state: directory
   register: tmpdir
 
-- set_fact:
+- name: set variables needed to build images
+  set_fact:
     openwrt_imgbuilder_dir:   "{{ tmpdir.path }}"
     openwrt_imgbuilder_files: "{{ tmpdir.path }}/files"
 
@@ -83,7 +84,8 @@
     trim_blocks: yes
   when: openwrt_groups is defined or openwrt_users is defined
 
-- unarchive:
+- name: extract image builder tarball
+  unarchive:
     copy: False
     src:  "{{ openwrt_download_dir }}/{{ openwrt_tarball_name }}"
     dest: "{{ openwrt_imgbuilder_dir }}"

--- a/ansible/roles/preseed/tasks/main.yml
+++ b/ansible/roles/preseed/tasks/main.yml
@@ -8,6 +8,7 @@
   template:
     src: "preseed_{{ install_distro }}-{{ install_codename }}.cfg.j2"
     dest: "{{ preseed_tmpdir }}/preseed.cfg"
+  register
 
 - name: Generate authorized_keys file
   authorized_key:
@@ -23,3 +24,5 @@
     stdin: |
       preseed.cfg
       authorized_keys
+  tags:
+  - skip_ansible_lint

--- a/ansible/roles/preseed/tasks/main.yml
+++ b/ansible/roles/preseed/tasks/main.yml
@@ -8,7 +8,6 @@
   template:
     src: "preseed_{{ install_distro }}-{{ install_codename }}.cfg.j2"
     dest: "{{ preseed_tmpdir }}/preseed.cfg"
-  register
 
 - name: Generate authorized_keys file
   authorized_key:

--- a/ansible/roles/reboot-and-wait/tasks/main.yml
+++ b/ansible/roles/reboot-and-wait/tasks/main.yml
@@ -3,6 +3,8 @@
   async: 1
   poll: 0
   ignore_errors: true
+  tags:
+  - skip_ansible_lint
 
 - name: waiting for host to come back
   wait_for_connection:


### PR DESCRIPTION
This enables ansible lint to check all roles on Travis. For now only the roles are checked and they also need to be manually added to the `_lint_roles.yml` playbook. Any new role needs to be added here. 

Later we should also check all playbooks and add a script that automatically enumerates all roles.