### PR TITLE
preseed/install: make disk selection work with udev device paths

### DIFF
--- a/ansible/host_vars/ctf/main.yml
+++ b/ansible/host_vars/ctf/main.yml
@@ -20,7 +20,7 @@ install:
   mem: 2048
   numcpu: 2
   disks:
-    primary: vda
+    primary: /dev/vda
     virtio:
       vda:
         vg: "{{ vm_host }}"

--- a/ansible/host_vars/gnocchi0/main.yml
+++ b/ansible/host_vars/gnocchi0/main.yml
@@ -10,4 +10,4 @@ network:
 
 install:
   disks:
-    primary: sda
+    primary: /dev/disk/by-id/ata-KINGSTON_SMS200S360G_50026B726A0002A2

--- a/ansible/host_vars/gnocchi1/main.yml
+++ b/ansible/host_vars/gnocchi1/main.yml
@@ -10,4 +10,4 @@ network:
 
 install:
   disks:
-    primary: sda
+    primary: /dev/disk/by-id/ata-KINGSTON_SMS200S360G_50026B726A00DFF4

--- a/ansible/host_vars/testvm/main.yml
+++ b/ansible/host_vars/testvm/main.yml
@@ -8,7 +8,7 @@ install:
   mem: 1024
   numcpu: 2
   disks:
-    primary: vda
+    primary: /dev/vda
     virtio:
       vda:
         vg: "{{ vm_host }}"

--- a/ansible/roles/preseed/templates/preseed_debian-stretch.cfg.j2
+++ b/ansible/roles/preseed/templates/preseed_debian-stretch.cfg.j2
@@ -41,7 +41,14 @@ d-i time/zone string Europe/Vienna
 d-i clock-setup/ntp boolean false
 
 
-d-i partman-auto/disk string /dev/{{ hostvars[hostname].install_cooked.disks.primary }}
+d-i partman/early_command string \
+    debconf-set partman-auto/disk "$(readlink -f {{ hostvars[hostname].install_cooked.disks.primary }})"; \
+    debconf-set grub-installer/bootdev "$(readlink -f {{ hostvars[hostname].install_cooked.disks.primary }})"; \
+    umount -l /media || true
+
+d-i grub-installer/choose_bootdev string manual
+d-i grub-installer/bootdev seen true
+
 d-i partman-auto/method string lvm
 d-i partman-auto/purge_lvm_from_device boolean true
 d-i partman-auto-lvm/new_vg_name string {{ hostname }}
@@ -100,7 +107,6 @@ d-i pkgsel/include string openssh-server python
 d-i pkgsel/upgrade select safe-upgrade
 popularity-contest popularity-contest/participate boolean false
 
-d-i grub-installer/choose_bootdev string /dev/{{ hostvars[hostname].install_cooked.disks.primary }}
 d-i grub-installer/only_debian boolean true
 d-i grub-installer/with_other_os boolean false
 

--- a/ansible/roles/preseed/templates/preseed_ubuntu-bionic.cfg.j2
+++ b/ansible/roles/preseed/templates/preseed_ubuntu-bionic.cfg.j2
@@ -46,7 +46,14 @@ d-i time/zone string Europe/Vienna
 d-i clock-setup/ntp boolean false
 
 
-d-i partman-auto/disk string /dev/{{ hostvars[hostname].install_cooked.disks.primary }}
+d-i partman/early_command string \
+    debconf-set partman-auto/disk "$(readlink -f {{ hostvars[hostname].install_cooked.disks.primary }})"; \
+    debconf-set grub-installer/bootdev "$(readlink -f {{ hostvars[hostname].install_cooked.disks.primary }})"; \
+    umount -l /media || true
+
+d-i grub-installer/choose_bootdev string manual
+d-i grub-installer/bootdev seen true
+
 d-i partman-auto/method string lvm
 d-i partman-auto/purge_lvm_from_device boolean true
 d-i partman-auto-lvm/new_vg_name string {{ hostname }}
@@ -106,7 +113,6 @@ d-i pkgsel/upgrade select safe-upgrade
 popularity-contest popularity-contest/participate boolean false
 d-i pkgsel/update-policy select none
 
-d-i grub-installer/choose_bootdev string /dev/{{ hostvars[hostname].install_cooked.disks.primary }}
 d-i grub-installer/only_debian boolean true
 d-i grub-installer/with_other_os boolean false
 

--- a/ansible/roles/preseed/templates/preseed_ubuntu-xenial.cfg.j2
+++ b/ansible/roles/preseed/templates/preseed_ubuntu-xenial.cfg.j2
@@ -46,7 +46,14 @@ d-i time/zone string Europe/Vienna
 d-i clock-setup/ntp boolean false
 
 
-d-i partman-auto/disk string /dev/{{ hostvars[hostname].install_cooked.disks.primary }}
+d-i partman/early_command string \
+    debconf-set partman-auto/disk "$(readlink -f {{ hostvars[hostname].install_cooked.disks.primary }})"; \
+    debconf-set grub-installer/bootdev "$(readlink -f {{ hostvars[hostname].install_cooked.disks.primary }})"; \
+    umount -l /media || true
+
+d-i grub-installer/choose_bootdev string manual
+d-i grub-installer/bootdev seen true
+
 d-i partman-auto/method string lvm
 d-i partman-auto/purge_lvm_from_device boolean true
 d-i partman-auto-lvm/new_vg_name string {{ hostname }}
@@ -107,7 +114,6 @@ popularity-contest popularity-contest/participate boolean false
 d-i pkgsel/update-policy select none
 d-i base-installer/kernel/override-image string linux-generic-hwe-16.04
 
-d-i grub-installer/choose_bootdev string /dev/{{ hostvars[hostname].install_cooked.disks.primary }}
 d-i grub-installer/only_debian boolean true
 d-i grub-installer/with_other_os boolean false
 


### PR DESCRIPTION
This fixes the issue with usb-install were the usb stick was detected as /dev/sda.

I tested this with `vm-install` as well as `usb-install`. Both `gnocchis` as well as `testvm` have been reinstalled using this change.