### PR TITLE
disable facts gathering for usb-install playbook

### DIFF
--- a/ansible/usb-install.yml
+++ b/ansible/usb-install.yml
@@ -2,6 +2,7 @@
 - name: Fetch debian installer and bake initrd
   hosts: "{{ hostname }}"
   connection: local
+  gather_facts: no
 
   vars_prompt:
     - name: usbdrive_path


### PR DESCRIPTION
Since the play is running with `connection: local` facts from the local machine could end up in the cache file for the host to be (re)installed.