### PR TITLE
don't force roaming on iot wifi

### DIFF
--- a/ansible/group_vars/accesspoints/main.yml
+++ b/ansible/group_vars/accesspoints/main.yml
@@ -22,10 +22,16 @@ accesspoint_zones:
     ssid: "realraum"
     encryption: "psk2"
     key: "{{ vault_accesspoint_zones.guests.key }}"
+    extra_options:
+      disassoc_low_ack: '1'
+      rsn_preauth: '1'
   # members:
   #   ssid: "r3members"
   #   encryption: "psk2"
   #   key: "{{ vault_accesspoint_zones.members.key }}"
+  #   extra_options:
+  #     disassoc_low_ack: '1'
+  #     rsn_preauth: '1'
 
 
 
@@ -113,11 +119,12 @@ accesspoint_wireless_ifaces_yaml: |
       device: 'radio{{ item.freq }}'
       network: '{{ zone }}'
       mode: 'ap'
-      disassoc_low_ack: '1'
-      rsn_preauth: '1'
       ssid: '{{ accesspoint_zones[zone].ssid }}{{ item.ssid }}'
       encryption: '{{ accesspoint_zones[zone].encryption }}'
       key: '{{ accesspoint_zones[zone].key }}'
+  {%     for opt, val in (accesspoint_zones[zone].extra_options | default({}) ).items() %}
+      {{ opt }}: '{{ val }}'
+  {%     endfor %}
   {%   endfor %}
   {% endfor %}
 


### PR DESCRIPTION
It looks like our changes to enforce roaming are not ideal for IOT Wifi since some of the small devices have low transmit power and get therefore disconnected regularly.
I think switching these settings off for IOT Wifi is ok but i very much like the change in the members/guest Wifi because at least i have much less troubles when roaming now. 