### PR TITLE
ansible/base: Workaround SACK DoS ([NFLX-2019-001])

### DIFF
--- a/ansible/roles/base/tasks/06net.yml
+++ b/ansible/roles/base/tasks/06net.yml
@@ -24,5 +24,10 @@
     # C.f. https://queue.acm.org/detail.cfm?id=3022184
     net.ipv4.tcp_congestion_control: bbr
 
+    # Disable Selective Acknowledgement (SACK)
+    # Workaround CVE-2019-11477, CVE-2019-11478, CVE-2019-11479
+    # See https://github.com/Netflix/security-bulletins/blob/master/advisories/third-party/2019-001.md
+    net.ipv4.tcp_sack: 0
+
   loop_control:
     label: "{{ item.key }}"


### PR DESCRIPTION
Disable Selective Acknowledgement (SACK); see [NFLX-2019-001], aka CVE-2019-1147{7,8,9}.

[NFLX-2019-001]: https://github.com/Netflix/security-bulletins/blob/master/advisories/third-party/2019-001.md