### PR TITLE
Topic/bootstraping improvements

### DIFF
--- a/ansible/roles/debian-installer/tasks/main.yml
+++ b/ansible/roles/debian-installer/tasks/main.yml
@@ -1,15 +1,15 @@
 - name: prepare directories for installer images
-  with_subelements:
-    - "{{ distros }}"
-    - arch
+  loop: "{{ distros | subelements('arch') }}"
+  loop_control:
+    label: "{{ item.0.distro }}/{{ item.0.codename }} {{ item.1 }}"
   file:
     name: "{{ debian_installer_path }}/{{ item.0.distro }}-{{ item.0.codename }}/{{ item.1 }}"
     state: directory
 
 - name: download installer kernel images
-  with_subelements:
-    - "{{ distros }}"
-    - arch
+  loop: "{{ distros | subelements('arch') }}"
+  loop_control:
+    label: "{{ item.0.distro }}/{{ item.0.codename }} {{ item.1 }}"
   get_url:
     url: "{{ debian_installer_url[item.0.distro] }}/dists/{{ item.0.codename }}/main/installer-{{ item.1 }}/current/images/netboot/{{ item.0.distro }}-installer/{{ item.1 }}/linux"
     dest: "{{ debian_installer_path }}/{{ item.0.distro }}-{{ item.0.codename }}/{{ item.1 }}/linux"
@@ -17,9 +17,9 @@
     force: "{{ debian_installer_force_download }}"
 
 - name: download installer initrd.gz
-  with_subelements:
-    - "{{ distros }}"
-    - arch
+  loop: "{{ distros | subelements('arch') }}"
+  loop_control:
+    label: "{{ item.0.distro }}/{{ item.0.codename }} {{ item.1 }}"
   get_url:
     url: "{{ debian_installer_url[item.0.distro] }}/dists/{{ item.0.codename }}/main/installer-{{ item.1 }}/current/images/netboot/{{ item.0.distro }}-installer/{{ item.1 }}/initrd.gz"
     dest: "{{ debian_installer_path }}/{{ item.0.distro }}-{{ item.0.codename }}/{{ item.1 }}/initrd.gz"

--- a/ansible/roles/preseed/defaults/main.yml
+++ b/ansible/roles/preseed/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+#preseed_force_net_ifnames_policy: path

--- a/ansible/roles/preseed/tasks/main.yml
+++ b/ansible/roles/preseed/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Copy initramfs into position
   copy:
     remote_src: yes
@@ -16,6 +17,21 @@
     path: "{{ preseed_tmpdir }}/authorized_keys"
     key: "{{ ssh_users_root | user_ssh_keys(users) | join('\n') }}"
 
+- name: force net interface name policy
+  when: preseed_force_net_ifnames_policy is defined
+  block:
+  - name: prepare directories to force network interface name policy
+    file:
+      path: "{{ preseed_tmpdir }}/etc/systemd/network"
+      state: directory
+
+  - name: install link unit to force network interface name policy
+    copy:
+      dest: "{{ preseed_tmpdir }}/etc/systemd/network/90-namepolicy.link"
+      content: |
+        [Link]
+        NamePolicy={{ preseed_force_net_ifnames_policy }}
+
 - name: Inject files into initramfs
   shell: cpio -H newc -o | gzip -9 >> 'initrd.preseed.gz'
   args:
@@ -23,5 +39,9 @@
     stdin: |
       preseed.cfg
       authorized_keys
+      etc/
+      etc/systemd/
+      etc/systemd/network/
+      etc/systemd/network/90-namepolicy.link
   tags:
   - skip_ansible_lint

--- a/ansible/roles/preseed/templates/preseed_debian-buster.cfg.j2
+++ b/ansible/roles/preseed/templates/preseed_debian-buster.cfg.j2
@@ -117,8 +117,14 @@ d-i preseed/late_command string \
     in-target bash -c "apt-get update -q && apt-get full-upgrade -y -q"; \
     in-target bash -c "passwd -d root && passwd -l root"; \
     in-target bash -c "sed -e 's/^allow-hotplug/auto/' -i /etc/network/interfaces"; \
-    mkdir -p -m 0700 /target/root/.ssh; \
-    cp /authorized_keys /target/root/.ssh/; \
-{% if hostvars[hostname].ansible_port is defined %}
-    in-target bash -c "sed -e 's/^\(\s*#*\s*Port.*\)/Port {{ hostvars[hostname].ansible_port }}/' -i /etc/ssh/sshd_config"
+{% if preseed_force_net_ifnames_policy is defined %}
+    mkdir -p /target/etc/systemd/network; \
+    in-target bash -c "echo '[Link]' > /etc/systemd/network/90-namepolicy.link"; \
+    in-target bash -c "echo 'NamePolicy={{ preseed_force_net_ifnames_policy }}' >> /etc/systemd/network/90-namepolicy.link"; \
+    in-target bash -c "update-initramfs -u"; \
 {% endif %}
+{% if hostvars[hostname].ansible_port is defined %}
+    in-target bash -c "sed -e 's/^\(\s*#*\s*Port.*\)/Port {{ hostvars[hostname].ansible_port }}/' -i /etc/ssh/sshd_config"; \
+{% endif %}
+    mkdir -p -m 0700 /target/root/.ssh; \
+    cp /authorized_keys /target/root/.ssh/

--- a/ansible/roles/preseed/templates/preseed_debian-buster.cfg.j2
+++ b/ansible/roles/preseed/templates/preseed_debian-buster.cfg.j2
@@ -9,14 +9,19 @@ d-i keyboard-configuration/xkb-keymap select us
 
 d-i hw-detect/load_firmware boolean false
 
-d-i netcfg/disable_dhcp boolean true
 d-i netcfg/choose_interface select {{ install_interface | default(hostvars[hostname].network_cooked.primary.interface) }}
+{% if 'install_dhcp' in hostvars[hostname] and hostvars[hostname].install_dhcp %}
+d-i netcfg/disable_dhcp boolean false
 d-i netcfg/disable_autoconfig boolean false
+{% else %}
+d-i netcfg/disable_dhcp boolean true
+d-i netcfg/disable_autoconfig boolean true
 d-i netcfg/get_ipaddress string {{ hostvars[hostname].network_cooked.primary.ip }}
 d-i netcfg/get_netmask string {{ hostvars[hostname].network_cooked.primary.mask }}
 d-i netcfg/get_gateway string {{ hostvars[hostname].network_cooked.primary.gateway }}
 d-i netcfg/get_nameservers string {{ hostvars[hostname].network_cooked.nameservers | join(' ') }}
 d-i netcfg/confirm_static boolean true
+{% endif %}
 
 d-i netcfg/hostname string {{ hostname }}
 d-i netcfg/get_hostname string {{ hostname }}

--- a/ansible/roles/preseed/templates/preseed_debian-stretch.cfg.j2
+++ b/ansible/roles/preseed/templates/preseed_debian-stretch.cfg.j2
@@ -117,8 +117,14 @@ d-i preseed/late_command string \
     in-target bash -c "apt-get update -q && apt-get full-upgrade -y -q"; \
     in-target bash -c "passwd -d root && passwd -l root"; \
     in-target bash -c "sed -e 's/^allow-hotplug/auto/' -i /etc/network/interfaces"; \
-    mkdir -p -m 0700 /target/root/.ssh; \
-    cp /authorized_keys /target/root/.ssh/; \
-{% if hostvars[hostname].ansible_port is defined %}
-    in-target bash -c "sed -e 's/^\(\s*#*\s*Port.*\)/Port {{ hostvars[hostname].ansible_port }}/' -i /etc/ssh/sshd_config"
+{% if preseed_force_net_ifnames_policy is defined %}
+    mkdir -p /target/etc/systemd/network; \
+    in-target bash -c "echo '[Link]' > /etc/systemd/network/90-namepolicy.link"; \
+    in-target bash -c "echo 'NamePolicy={{ preseed_force_net_ifnames_policy }}' >> /etc/systemd/network/90-namepolicy.link"; \
+    in-target bash -c "update-initramfs -u"; \
 {% endif %}
+{% if hostvars[hostname].ansible_port is defined %}
+    in-target bash -c "sed -e 's/^\(\s*#*\s*Port.*\)/Port {{ hostvars[hostname].ansible_port }}/' -i /etc/ssh/sshd_config"; \
+{% endif %}
+    mkdir -p -m 0700 /target/root/.ssh; \
+    cp /authorized_keys /target/root/.ssh/

--- a/ansible/roles/preseed/templates/preseed_debian-stretch.cfg.j2
+++ b/ansible/roles/preseed/templates/preseed_debian-stretch.cfg.j2
@@ -9,14 +9,19 @@ d-i keyboard-configuration/xkb-keymap select us
 
 d-i hw-detect/load_firmware boolean false
 
-d-i netcfg/disable_dhcp boolean true
 d-i netcfg/choose_interface select {{ install_interface | default(hostvars[hostname].network_cooked.primary.interface) }}
+{% if 'install_dhcp' in hostvars[hostname] and hostvars[hostname].install_dhcp %}
+d-i netcfg/disable_dhcp boolean false
 d-i netcfg/disable_autoconfig boolean false
+{% else %}
+d-i netcfg/disable_dhcp boolean true
+d-i netcfg/disable_autoconfig boolean true
 d-i netcfg/get_ipaddress string {{ hostvars[hostname].network_cooked.primary.ip }}
 d-i netcfg/get_netmask string {{ hostvars[hostname].network_cooked.primary.mask }}
 d-i netcfg/get_gateway string {{ hostvars[hostname].network_cooked.primary.gateway }}
 d-i netcfg/get_nameservers string {{ hostvars[hostname].network_cooked.nameservers | join(' ') }}
 d-i netcfg/confirm_static boolean true
+{% endif %}
 
 d-i netcfg/hostname string {{ hostname }}
 d-i netcfg/get_hostname string {{ hostname }}

--- a/ansible/roles/preseed/templates/preseed_ubuntu-bionic.cfg.j2
+++ b/ansible/roles/preseed/templates/preseed_ubuntu-bionic.cfg.j2
@@ -124,8 +124,14 @@ d-i preseed/late_command string \
     in-target bash -c "apt-get update -q && apt-get full-upgrade -y -q"; \
     in-target bash -c "passwd -d root && passwd -l root"; \
     in-target bash -c "sed -e 's/^allow-hotplug/auto/' -i /etc/network/interfaces"; \
-    mkdir -p -m 0700 /target/root/.ssh; \
-    cp /authorized_keys /target/root/.ssh/; \
-{% if hostvars[hostname].ansible_port is defined %}
-    in-target bash -c "sed -e 's/^\(\s*#*\s*Port.*\)/Port {{ hostvars[hostname].ansible_port }}/' -i /etc/ssh/sshd_config"
+{% if preseed_force_net_ifnames_policy is defined %}
+    mkdir -p /target/etc/systemd/network; \
+    in-target bash -c "echo '[Link]' > /etc/systemd/network/90-namepolicy.link"; \
+    in-target bash -c "echo 'NamePolicy={{ preseed_force_net_ifnames_policy }}' >> /etc/systemd/network/90-namepolicy.link"; \
+    in-target bash -c "update-initramfs -u"; \
 {% endif %}
+{% if hostvars[hostname].ansible_port is defined %}
+    in-target bash -c "sed -e 's/^\(\s*#*\s*Port.*\)/Port {{ hostvars[hostname].ansible_port }}/' -i /etc/ssh/sshd_config"; \
+{% endif %}
+    mkdir -p -m 0700 /target/root/.ssh; \
+    cp /authorized_keys /target/root/.ssh/

--- a/ansible/roles/preseed/templates/preseed_ubuntu-bionic.cfg.j2
+++ b/ansible/roles/preseed/templates/preseed_ubuntu-bionic.cfg.j2
@@ -13,14 +13,19 @@ d-i keyboard-configuration/layoutcode string us
 
 d-i hw-detect/load_firmware boolean false
 
-d-i netcfg/disable_dhcp boolean true
 d-i netcfg/choose_interface select {{ install_interface | default(hostvars[hostname].network_cooked.primary.interface) }}
+{% if 'install_dhcp' in hostvars[hostname] and hostvars[hostname].install_dhcp %}
+d-i netcfg/disable_dhcp boolean false
 d-i netcfg/disable_autoconfig boolean false
+{% else %}
+d-i netcfg/disable_dhcp boolean true
+d-i netcfg/disable_autoconfig boolean true
 d-i netcfg/get_ipaddress string {{ hostvars[hostname].network_cooked.primary.ip }}
 d-i netcfg/get_netmask string {{ hostvars[hostname].network_cooked.primary.mask }}
 d-i netcfg/get_gateway string {{ hostvars[hostname].network_cooked.primary.gateway }}
 d-i netcfg/get_nameservers string {{ hostvars[hostname].network_cooked.nameservers | join(' ') }}
 d-i netcfg/confirm_static boolean true
+{% endif %}
 
 d-i netcfg/hostname string {{ hostname }}
 d-i netcfg/get_hostname string {{ hostname }}

--- a/ansible/roles/preseed/templates/preseed_ubuntu-xenial.cfg.j2
+++ b/ansible/roles/preseed/templates/preseed_ubuntu-xenial.cfg.j2
@@ -124,8 +124,14 @@ d-i preseed/late_command string \
     in-target bash -c "apt-get update -q && apt-get full-upgrade -y -q"; \
     in-target bash -c "passwd -d root && passwd -l root"; \
     in-target bash -c "sed -e 's/^allow-hotplug/auto/' -i /etc/network/interfaces"; \
-    mkdir -p -m 0700 /target/root/.ssh; \
-    cp /authorized_keys /target/root/.ssh/; \
-{% if hostvars[hostname].ansible_port is defined %}
-    in-target bash -c "sed -e 's/^\(\s*#*\s*Port.*\)/Port {{ hostvars[hostname].ansible_port }}/' -i /etc/ssh/sshd_config"
+{% if preseed_force_net_ifnames_policy is defined %}
+    mkdir -p /target/etc/systemd/network; \
+    in-target bash -c "echo '[Link]' > /etc/systemd/network/90-namepolicy.link"; \
+    in-target bash -c "echo 'NamePolicy={{ preseed_force_net_ifnames_policy }}' >> /etc/systemd/network/90-namepolicy.link"; \
+    in-target bash -c "update-initramfs -u"; \
 {% endif %}
+{% if hostvars[hostname].ansible_port is defined %}
+    in-target bash -c "sed -e 's/^\(\s*#*\s*Port.*\)/Port {{ hostvars[hostname].ansible_port }}/' -i /etc/ssh/sshd_config"; \
+{% endif %}
+    mkdir -p -m 0700 /target/root/.ssh; \
+    cp /authorized_keys /target/root/.ssh/

--- a/ansible/roles/preseed/templates/preseed_ubuntu-xenial.cfg.j2
+++ b/ansible/roles/preseed/templates/preseed_ubuntu-xenial.cfg.j2
@@ -13,14 +13,19 @@ d-i keyboard-configuration/layoutcode string us
 
 d-i hw-detect/load_firmware boolean false
 
-d-i netcfg/disable_dhcp boolean true
 d-i netcfg/choose_interface select {{ install_interface | default(hostvars[hostname].network_cooked.primary.interface) }}
+{% if 'install_dhcp' in hostvars[hostname] and hostvars[hostname].install_dhcp %}
+d-i netcfg/disable_dhcp boolean false
 d-i netcfg/disable_autoconfig boolean false
+{% else %}
+d-i netcfg/disable_dhcp boolean true
+d-i netcfg/disable_autoconfig boolean true
 d-i netcfg/get_ipaddress string {{ hostvars[hostname].network_cooked.primary.ip }}
 d-i netcfg/get_netmask string {{ hostvars[hostname].network_cooked.primary.mask }}
 d-i netcfg/get_gateway string {{ hostvars[hostname].network_cooked.primary.gateway }}
 d-i netcfg/get_nameservers string {{ hostvars[hostname].network_cooked.nameservers | join(' ') }}
 d-i netcfg/confirm_static boolean true
+{% endif %}
 
 d-i netcfg/hostname string {{ hostname }}
 d-i netcfg/get_hostname string {{ hostname }}

--- a/ansible/roles/vm/define/defaults/main.yml
+++ b/ansible/roles/vm/define/defaults/main.yml
@@ -1,3 +1,4 @@
+---
 vm_define_autostart: "{{ not vm_define_installer and hostvars[hostname].install_cooked.autostart | default(False) }}"
 vm_define_start: yes
 

--- a/ansible/roles/vm/define/tasks/main.yml
+++ b/ansible/roles/vm/define/tasks/main.yml
@@ -24,7 +24,7 @@
         command: undefine
 
 
-- name: redefine vm
+- name: define vm
   virt:
     command: define
     xml: "{{ lookup('template', 'libvirt-domain.xml.j2') }}"
@@ -43,8 +43,7 @@
         timeout: 10
 
 - name: mark vm as autostarted
-  when: vm_define_autostart | bool
   virt:
     name: "{{ hostname }}"
-    autostart: yes
+    autostart: "{{ vm_define_autostart }}"
     command: info ## virt module needs either command or state

--- a/ansible/roles/vm/host/tasks/main.yml
+++ b/ansible/roles/vm/host/tasks/main.yml
@@ -7,6 +7,8 @@
         libvirt-daemon-system
       - python-libvirt
       - haveged
+      - bridge-utils
+      - acl
     state: present
 
 - name: configure haveged

--- a/ansible/roles/vm/install/tasks/main.yml
+++ b/ansible/roles/vm/install/tasks/main.yml
@@ -17,8 +17,9 @@
         name: preseed
       vars:
         ssh_users_root: "{{ hostvars[hostname].ssh_users_root }}"
-        install_interface: enp1s1
         preseed_tmpdir: "{{ tmpdir.path }}"
+        preseed_force_net_ifnames_policy: path
+        install_interface: enp1s1
 
     - name: Make preseed workdir readable by qemu
       acl:

--- a/ansible/roles/vm/install/tasks/main.yml
+++ b/ansible/roles/vm/install/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: create disks for vm
   with_dict: "{{ hostvars[hostname].install_cooked.disks.virtio | default({}) | combine(hostvars[hostname].install_cooked.disks.scsi | default({})) }}"
+  loop_control:
+    label: "{{ item.value.vg }} / {{ item.value.lv }}  ({{ item.value.size }})"
   lvol:
     vg: "{{ item.value.vg }}"
     lv: "{{ item.value.lv }}"

--- a/ansible/roles/vm/network/tasks/main.yml
+++ b/ansible/roles/vm/network/tasks/main.yml
@@ -11,6 +11,7 @@
     - name: install systemd network link units
       with_items: "{{ network.systemd_link.interfaces }}"
       loop_control:
+        label: "{{ item.name }}"
         index_var: interface_index
       template:
         src: systemd.link.j2

--- a/ansible/vm-install.sh
+++ b/ansible/vm-install.sh
@@ -15,5 +15,7 @@ shift
 echo "installing $name with $distro/$codename"
 echo ""
 
+rm -f ".cache/facts/$name"
+
 echo "######## running the install playbook ########"
 exec ansible-playbook -e "hostname=$name" -e "install_distro=$distro" -e "install_codename=$codename" $@ $(basename "$0" .sh).yml


### PR DESCRIPTION
This PR contains various fixes for bootstraping hosts. The most prominent is the introduction of a variable to force a particular network interface naming policy. This is needed because Debian Buster introduced a new naming policy that is incompatible to the way we do network interface assignments in virtual machines. 
Other new options allow installation of machines using DHCP and improved handling of the VM autostart flag.

This PR is based on the ansible-2.8 fix branch which should be merged first.