### PR TITLE
documentation of hack to make door_daemon run on openwrt based torwae…

### DIFF
--- a/ansible/roles/openwrt/image/tasks/door_daemon.yml
+++ b/ansible/roles/openwrt/image/tasks/door_daemon.yml
@@ -1,0 +1,33 @@
+---
+
+# FIXME - only used as a notepad for necessary steps
+#
+#
+## Document current state (hack to make it just work till next reboot)
+#
+# - does not work after reboot, needs to be manually synced over
+# - wrong locations because ext4 from torwaechter is RO because of fs-errors
+# - /run is missing on torwaechter? (is the latest ansible applied on torwaechter?)
+# - properly run as tuerd (just guessed, but user/groups seem to be thought for this)
+#
+## Open Questions
+#
+# - how to integrate updates of key file (currently just synced once)
+# - where to store key file
+#
+## TODO
+#
+# - proper rc.common init script (just put into start()/stop()/restart() functions)
+# - start at boot, create a boot() function and call start there in the init script
+# - check status of door_client and open/close via ssh
+#
+## CMDs to make the hack work
+#
+# files for usb device /dev/door (available on device, but could not find them in any repo)
+#   rsync door_and_sensors/scripts/door.tty root@torwaechter.mgmt.realraum.at:/etc/hotplug.d/tty/
+#   rsync door_and_sensors/scripts/door.usb root@torwaechter.mgmt.realraum.at:/etc/hotplug.d/usb/
+
+# files for door_daemon
+#   rsync door_and_sensors/initscripts/tuer_core.openwrt root@torwaechter.mgmt.realraum.at:/tmp/tuer_core
+#   rsync door_and_sensors/initscripts/tuer.default root@torwaechter.mgmt.realraum.at:/tmp/tuer
+#   rsync keys/keys root@torwaechter.mgmt.realraum.at:/tmp/keys


### PR DESCRIPTION
debugged door_daemon on torwaechter together with @PeterTheOne and got a first version of door_daemon running, started through an init script that's able to run on torwaechter.

init script is available, properly running as tuerd (as thought?)

We've put all files into https://github.com/realraum/door_and_sensors/tree/make_door_daemon_great_again as they where initially there.

A few Questions:

- Should those files be put into this repo?
- What about the hotplugd files i found on torwaechter that seem to make /dev/door working and are missing in ansible?
- How to integrate the needed files and cmds into this ansible?
- Can i safely re-produce torwaechter from this ansible, just asking to be sure (eg. /run is missing there but is in this ansible repo)

Outcome:
door_locked: True in status.json is set when door is closed :)