### PR TITLE
Drop use of rngd on recent-ish kernels

### DIFF
--- a/ansible/roles/vm/guest/tasks/main.yml
+++ b/ansible/roles/vm/guest/tasks/main.yml
@@ -1,28 +1,14 @@
-- name: Install rngd
+- name: Install and configure rngd (on kernel < 3.17)
+  when: ansible_kernel is version('3.17', '<')
+  import_tasks: rngd.yml
+
+- name: Uninstall rngd (on kernel >= 3.17)
+  when: ansible_kernel is version('3.17', '>=')
   apt:
     name: rng-tools
-    state: present
-    force_apt_get: yes
-
-- name: Configure rngd [1/2]
-  lineinfile:
-    path: /etc/default/rng-tools
-    line: '{{ item.key }}={{ item.value }}'
-    regexp: '^#?{{ item.key }}='
-  with_dict: '{{ rngd_config }}'
-  loop_control:
-    label: "{{ item.key }}"
-  notify: restart rngd
-
-- name: Configure rngd [2/2]
-  lineinfile:
-    path: /etc/default/rng-tools
-    regexp: '^{{ item.key }}=(?!{{ item.value }})'
     state: absent
-  with_dict: '{{ rngd_config }}'
-  loop_control:
-    label: "{{ item.key }}"
-  notify: restart rngd
+    purge: yes
+
 
 - name: Provide a root shell on the VM console [1/2]
   file:

--- a/ansible/roles/vm/guest/tasks/main.yml
+++ b/ansible/roles/vm/guest/tasks/main.yml
@@ -21,4 +21,4 @@
     content: |
       [Service]
       ExecStart=
-      ExecStart=-/sbin/agetty --keep-baud 115200,38400,9600 --noclear --autologin root --login-pause --host {{ vm_host }} %I $TERM
+      ExecStart=-/sbin/agetty --keep-baud 115200,38400,9600 --noclear --autologin root --login-pause --host {{ vm_install_host }} %I $TERM

--- a/ansible/roles/vm/guest/tasks/rngd.yml
+++ b/ansible/roles/vm/guest/tasks/rngd.yml
@@ -1,0 +1,25 @@
+- name: Install rngd
+  apt:
+    name: rng-tools
+    state: present
+    force_apt_get: yes
+
+- name: Configure rngd [1/2]
+  lineinfile:
+    path: /etc/default/rng-tools
+    line: '{{ item.key }}={{ item.value }}'
+    regexp: '^#?{{ item.key }}='
+  with_dict: '{{ rngd_config }}'
+  loop_control:
+    label: "{{ item.key }}"
+  notify: restart rngd
+
+- name: Configure rngd [2/2]
+  lineinfile:
+    path: /etc/default/rng-tools
+    regexp: '^{{ item.key }}=(?!{{ item.value }})'
+    state: absent
+  with_dict: '{{ rngd_config }}'
+  loop_control:
+    label: "{{ item.key }}"
+  notify: restart rngd


### PR DESCRIPTION
khwrngd provides the same functionality as rngd here, but is integrated in the
kernel, and started by default by the hwrng driver as soon as the device is
initialized.

It was added in Linux 3.17 by the following commit:

> commit be4000bc4644d027c519b6361f5ae3bbfc52c347
> Author: Torsten Duwe <duwe@lst.de>
> Date:   Sat Jun 14 23:46:03 2014 -0400
>
> hwrng: create filler thread
>
> This can be viewed as the in-kernel equivalent of hwrngd;
> like FUSE it is a good thing to have a mechanism in user land,
> but for some reasons (simplicity, secrecy, integrity, speed)
> it may be better to have it in kernel space.
>
> This patch creates a thread once a hwrng registers, and uses
> the previously established add_hwgenerator_randomness() to feed
> its data to the input pool as long as needed. A derating factor
> is used to bias the entropy estimation and to disable this
> mechanism entirely when set to zero.

Also added a fix to `vm/guest` so I could run the role in check mode to test it.