### PR TITLE
Setup an apt-cacher VM for internal realraum use

### DIFF
--- a/ansible/group_vars/all/main.yml
+++ b/ansible/group_vars/all/main.yml
@@ -12,3 +12,7 @@ root_password: "{{ vault_root_password }}"
 ## SSH keys for root, default to NOC's
 
 ssh_users_root: "{{ user_groups.noc }}"
+
+base_debian_mirrors:
+  - https://deb.realraum.at
+  - https://debian.ffgraz.net

--- a/ansible/host_playbooks/deb.yml
+++ b/ansible/host_playbooks/deb.yml
@@ -88,6 +88,10 @@
           - https://debian.ffgraz.net/debian-security
           - http://cdn-fastly.deb.debian.org/debian-security
 
+        grml:
+          - https://debian.ffgraz.net/grml
+          - https://deb.grml.org/
+
         pi:
           - https://debian.ffgraz.net/pi
           - https://archive.raspberrypi.org/debian

--- a/ansible/host_playbooks/deb.yml
+++ b/ansible/host_playbooks/deb.yml
@@ -62,7 +62,7 @@
         Remap-raspbian: /raspbian ; file:backends_raspbian
 
 
-    - name: Configure's acng's backends
+    - name: Configure acng's backends
       notify: restart acng
       copy:
         dest: /etc/apt-cacher-ng/backends_{{ item.key }}

--- a/ansible/host_playbooks/deb.yml
+++ b/ansible/host_playbooks/deb.yml
@@ -1,0 +1,97 @@
+---
+- name: Basic Setup for deb.realraum.at
+  hosts: deb
+  roles:
+  - role: base
+  
+- name: Set up data volume for apt-cacher-ng
+  hosts: deb
+  tasks:
+    - name: Format the data volume
+      filesystem:
+        dev: /dev/vdb
+        fstype: ext4
+        resizefs: yes
+
+    - name: Setup mountpoint
+      mount:
+        path:   /var/cache/apt-cacher-ng
+        src:    /dev/vdb
+        state:  mounted
+        fstype: ext4
+
+    - name: Create user/group apt-cacher-ng
+      user:
+        name: apt-cacher-ng
+        system: yes
+        shell: /usr/sbin/nologin
+        home: /var/cache/apt-cacher-ng
+        create_home: no
+
+    - name: Set up permissions on /var/cache/apt-cacher-ng
+      file:
+        path: /var/cache/apt-cacher-ng
+        owner: apt-cacher-ng
+        group: apt-cacher-ng
+
+- name: Set up apt-cacher-ng
+  hosts: deb
+  handlers:
+    - name: restart acng
+      service:
+        name: apt-cacher-ng
+        state: restarted
+
+  tasks:
+    - name: Install acng
+      apt:
+        name: apt-cacher-ng
+        state: present
+
+    - name: Configure acng
+      notify: restart acng
+      lineinfile:
+        path: /etc/apt-cacher-ng/acng.conf
+        line: "{{ item.key }}: {{ item.value }}"
+        regexp: "^(#\\s*)?{{ item.key }}:"
+
+      loop_control:
+        label: "{{ item.key }}"
+      with_dict:
+        BindAddress: deb.http.realraum.at
+        Port: 8080
+        ForceManaged: 1
+        Remap-debsec: /debian-security ; file:backends_debian_security
+        Remap-grml: /grml ; file:backends_grml
+        Remap-pi: /pi ; file:backends_pi
+        Remap-raspbian: /raspbian ; file:backends_raspbian
+
+
+    - name: Configure's acng's backends
+      notify: restart acng
+      copy:
+        dest: /etc/apt-cacher-ng/backends_{{ item.key }}
+        content: |
+          {% for backend in item.value %}
+          {{ backend }}
+          {% endfor %}
+        mode: 0644
+
+      loop_control:
+        label: "{{ item.key }}"
+      with_dict:
+        debian:
+          - https://debian.ffgraz.net/debian
+          - http://cdn-fastly.deb.debian.org/debian
+
+        debian_security:
+          - https://debian.ffgraz.net/debian-security
+          - http://cdn-fastly.deb.debian.org/debian-security
+
+        pi:
+          - https://debian.ffgraz.net/pi
+          - https://archive.raspberrypi.org/debian
+
+        raspbian:
+          - https://debian.ffgraz.net/raspbian
+          - https://archive.raspbian.org/raspbian

--- a/ansible/host_playbooks/deb.yml
+++ b/ansible/host_playbooks/deb.yml
@@ -1,9 +1,4 @@
 ---
-- name: Basic Setup for deb.realraum.at
-  hosts: deb
-  roles:
-  - role: base
-  
 - name: Set up data volume for apt-cacher-ng
   hosts: deb
   tasks:
@@ -99,3 +94,8 @@
         raspbian:
           - https://debian.ffgraz.net/raspbian
           - https://archive.raspbian.org/raspbian
+
+- name: Basic Setup for deb.realraum.at
+  hosts: deb
+  roles:
+  - role: base

--- a/ansible/host_vars/alfred/main.yml
+++ b/ansible/host_vars/alfred/main.yml
@@ -10,4 +10,5 @@ vm_host:
     nameservers: "{{ net.mgmt.dns }}"
     indices:
       metrics: 74
+      deb: 75
       testvm: 99

--- a/ansible/host_vars/deb/main.yml
+++ b/ansible/host_vars/deb/main.yml
@@ -1,0 +1,42 @@
+---
+localconfig_ssh_config_user: root
+
+vm_host: alfred
+
+install:
+  host: "{{ vm_host }}"
+  mem: 1024
+  numcpu: 2
+  disks:
+    primary: /dev/vda
+    virtio:
+      vda:
+        vg: "{{ vm_host }}"
+        lv: "{{ inventory_hostname }}"
+        size: 5g
+      vdb:
+        vg: "{{ vm_host }}"
+        lv: "{{ inventory_hostname }}-data"
+        size: 20g
+
+  interfaces:
+  - bridge: "{{ hostvars[vm_host].vm_host.network.interface }}"
+    name: mgmt0
+  - bridge: "br-svc"
+    name: svc0
+  autostart: True
+
+network:
+  nameservers: "{{ hostvars[vm_host].vm_host.network.nameservers }}"
+  domain: realraum.at
+  systemd_link:
+    interfaces: "{{ install.interfaces }}"
+  primary:
+    interface: mgmt0
+    ip: "{{ (hostvars[vm_host].vm_host.network.ip+'/'+hostvars[vm_host].vm_host.network.mask) | ipaddr(hostvars[vm_host].vm_host.network.indices[inventory_hostname]) | ipaddr('address') }}"
+    mask: "{{ hostvars[vm_host].vm_host.network.mask }}"
+    gateway: "{{ hostvars[vm_host].vm_host.network.gateway | default(hostvars[vm_host].vm_host.network.ip) }}"
+  secondary:
+    svc0:
+      ip:   192.168.34.75
+      mask: 255.255.255.0

--- a/ansible/host_vars/vex/main.yml
+++ b/ansible/host_vars/vex/main.yml
@@ -4,3 +4,7 @@ sshd_allowusers_host:
   - www
   - www-data
   - acme
+
+base_debian_mirrors:
+  - https://debian.ffgraz.net
+  - https://deb.realraum.at

--- a/ansible/hosts.ini
+++ b/ansible/hosts.ini
@@ -14,6 +14,7 @@ hacksch
 r3home
 tickets
 gnocchi[0:1]
+deb
 
 ## TODO: remove the variable once https://github.com/ansible/ansible/issues/39119 is fixed
 metrics localconfig_ssh_config_user=root
@@ -46,6 +47,7 @@ virtualservers-alfred
 athsdisc
 calendar
 ctf
+deb
 entrance
 galley
 hacksch

--- a/ansible/roles/base/tasks/02debian.yml
+++ b/ansible/roles/base/tasks/02debian.yml
@@ -5,6 +5,17 @@
     dest: /etc/apt/apt.conf.d/
     mode: 0644
 
+- name: Install apt-transport-https
+  apt:
+    name: apt-transport-https
+    state: present
+
+- name: Template sources.list
+  template:
+    dest: /etc/apt/sources.list
+    src: sources.list.j2
+    mode: 0644
+
 - name: install basic packages
   apt:
     name:

--- a/ansible/roles/base/templates/sources.list.j2
+++ b/ansible/roles/base/templates/sources.list.j2
@@ -1,7 +1,7 @@
 {% macro deb(path, suite) -%}
 {% for type in ['deb', 'deb-src'] %}
 {% for mirror in base_debian_mirrors %}
-{{ type }}	{{ mirror }}/{{ path }}	main
+{{ type }} {{ mirror }}/{{ path }}	{{ suite }}	main
 {% endfor %}
 {% endfor %}
 {%- endmacro %}

--- a/ansible/roles/base/templates/sources.list.j2
+++ b/ansible/roles/base/templates/sources.list.j2
@@ -1,0 +1,17 @@
+{% macro deb(path, suite) -%}
+{% for type in ['deb', 'deb-src'] %}
+{% for mirror in base_debian_mirrors %}
+{{ type }}	{{ mirror }}/{{ path }}	main
+{% endfor %}
+{% endfor %}
+{%- endmacro %}
+{{ ansible_managed | comment }}
+
+# Main Debian archive
+{{ deb('debian', ansible_distribution_release) }}
+
+# Security updates
+{{ deb('debian-security', ansible_distribution_release + '/updates') }}
+
+# {{ ansible_distribution_release }}-updates, previously known as 'volatile'
+{{ deb('debian', ansible_distribution_release + '-updates') }}

--- a/ansible/roles/vm/network/templates/interfaces.j2
+++ b/ansible/roles/vm/network/templates/interfaces.j2
@@ -15,3 +15,16 @@ iface {{ network.primary.interface }} inet static
   gateway {{ network.primary.gateway }}
   pre-up echo 0 > /proc/sys/net/ipv6/conf/$IFACE/accept_ra
   pre-up echo 0 > /proc/sys/net/ipv6/conf/$IFACE/autoconf
+
+{% if 'secondary' in network %}
+# Secondary network interfaces
+{% for iface, v in network['secondary'].items() %}
+auto {{ iface }}
+iface {{ iface }} inet static
+  address {{ v.ip }}
+  netmask {{ v.mask }}
+  pre-up echo 0 > /proc/sys/net/ipv6/conf/$IFACE/accept_ra
+  pre-up echo 0 > /proc/sys/net/ipv6/conf/$IFACE/autoconf
+
+{% endfor %}
+{% endif %}

--- a/ansible/vm-install.yml
+++ b/ansible/vm-install.yml
@@ -47,8 +47,6 @@
   - role: vm/network
   - role: vm/guest
 
-- import_playbook: "host_playbooks/{{ hostname }}.yml"
-
 - name: reboot and wait for VM come back
   hosts: "{{ hostname }}"
   gather_facts: no
@@ -56,3 +54,5 @@
   - role: reboot-and-wait
     reboot_delay: 10
     reboot_timeout: 120
+
+- import_playbook: "host_playbooks/{{ hostname }}.yml"


### PR DESCRIPTION
- [x] Improve VM provisioning automation to support this VM's needs
- [x] Provision `deb` VM, fully automate its setup
- [x] Update `base` role to use the new, local cache

Repos are provided for `/debian`, `/debian-security`, `/grml`, `/pi` (Raspberry Pi), and `/raspbian`.

I ran the VM install playbook, and manually configured `entrance` and the `realraum.at` DNS zone so the apt cache is operational.  Nginx (on `entrance`) limits access to `192.168.0.0/16`, our routable IPv4 and IPv6 space (`89.106.211.32/27`, `89.106.211.64/27`, `2a02:3e0:4000:1::/64`), and vex, so this isn't useable as a public cache.