### PR TITLE
add iot vm for new node-red room automation

### DIFF
--- a/ansible/host_vars/iot/main.yml
+++ b/ansible/host_vars/iot/main.yml
@@ -1,0 +1,42 @@
+---
+ssh_users_root:
+  - equinox
+  - nicoo
+  - gebi
+
+#sshd_allowusers_host:
+#  - ...
+
+# SSH configuration
+## There are no individual user accounts
+localconfig_ssh_config_user: root
+
+# VM installation
+vm_host: alfred
+
+install:
+  host: "{{ vm_host }}"
+  mem: 2048
+  numcpu: 2
+  disks:
+    primary: /dev/vda
+    virtio:
+      vda:
+        vg: "{{ vm_host }}"
+        lv: "{{ inventory_hostname }}"
+        size: 10g
+  interfaces:
+  - bridge: "{{ hostvars[vm_host].vm_host.network.interface }}"
+    name: mgmt0
+  autostart: True
+
+network:
+  nameservers: "{{ hostvars[vm_host].vm_host.network.nameservers }}"
+  domain: realraum.at
+  systemd_link:
+    interfaces: "{{ install.interfaces }}"
+  primary:
+    interface: mgmt0
+    ip: "{{ (hostvars[vm_host].vm_host.network.ip+'/'+hostvars[vm_host].vm_host.network.mask) | ipaddr(hostvars[vm_host].vm_host.network.indices[inventory_hostname]) | ipaddr('address') }}"
+    mask: "{{ hostvars[vm_host].vm_host.network.mask }}"
+    gateway: "{{ hostvars[vm_host].vm_host.network.gateway | default(hostvars[vm_host].vm_host.network.ip) }}"

--- a/ansible/hosts.ini
+++ b/ansible/hosts.ini
@@ -49,6 +49,7 @@ hacksch
 metrics
 r3home
 testvm
+iot
 
 [virtualservers-alfred:vars]
 vm_install_host = alfred


### PR DESCRIPTION
new vm to host iot stuff, starting with node-red for realraum room automation

target will be to have sw only from ci/cd piplines in this VM to start cleaning up iot stuff a bit :)